### PR TITLE
feat!: require @reduxjs/toolkit v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This redux middleware enhances redux-saga with redux-thunk capabilites.
 
+> **Requires `@reduxjs/toolkit` v2+** and `redux-saga` v1+.
+
 ## Usage
 
 ```ts
@@ -41,7 +43,7 @@ export const fetchTasks = createThagaAction(
     // arguments: (actionPayload, action, ...restArgs)
     const tasks = (yield call(taskApi)) as Task[];
     return tasks;
-  }
+  },
 );
 
 export const { actions, reducer: tasksReducer } = createSlice({

--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -18,7 +18,8 @@
       },
       "devDependencies": {
         "@types/react": "^18.2.6",
-        "@types/react-dom": "^18.2.4"
+        "@types/react-dom": "^18.2.4",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -15721,16 +15722,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-compare": {

--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -8,11 +8,11 @@
       "name": "redux-thunk-react-example",
       "version": "0.1.0",
       "dependencies": {
-        "@hvish/redux-thaga": "file:../hvish-redux-thaga-0.1.0.tgz",
-        "@reduxjs/toolkit": "^1.9.5",
+        "@hvish/redux-thaga": "file:../hvish-redux-thaga-0.2.0.tgz",
+        "@reduxjs/toolkit": "^2.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^8.0.5",
+        "react-redux": "^9.1.2",
         "react-scripts": "5.0.1",
         "redux-saga": "^1.2.3"
       },
@@ -2260,12 +2260,15 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@hvish/redux-thaga": {
-      "version": "0.1.0",
-      "resolved": "file:../hvish-redux-thaga-0.1.0.tgz",
-      "integrity": "sha512-TZmsJgtCEzcJJLKaBc3RgiNQ2Rz39+2H5AxiDR8QjSH0wrG/Qhnjz6ZdybXTTrGCvBBGWPd5fE9lOOd7/NTvPQ==",
+      "version": "0.2.0",
+      "resolved": "file:../hvish-redux-thaga-0.2.0.tgz",
+      "integrity": "sha512-c+EsaREQ26v2Pe9irGXr9NAdpDI8Xu+nNtAKQT9n4MgyB2YMmhq4Y8FPAsIorZ52P7gt0QkjYs8pT76m2hrvqA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
       "peerDependencies": {
-        "@reduxjs/toolkit": ">= 1",
+        "@reduxjs/toolkit": ">= 2",
         "redux-saga": ">= 1"
       }
     },
@@ -3122,6 +3125,15 @@
         "url": "https://opencollective.com/redux-saga"
       }
     },
+    "node_modules/@redux-saga/core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/@redux-saga/deferred": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.2.1.tgz",
@@ -3155,18 +3167,21 @@
       "integrity": "sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA=="
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
-      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -3175,6 +3190,16 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3276,6 +3301,18 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -3635,15 +3672,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3711,7 +3739,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "devOptional": true
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -3729,20 +3758,21 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.6.tgz",
-      "integrity": "sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
       "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3759,11 +3789,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -3815,9 +3840,10 @@
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -5969,9 +5995,11 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8235,19 +8263,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -13876,36 +13891,21 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-redux": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
-      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4"
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         },
         "redux": {
@@ -14037,12 +14037,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-saga": {
       "version": "1.2.3",
@@ -14053,11 +14051,12 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -14187,9 +14186,10 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -15892,11 +15892,12 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -13,7 +13,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4"
+    "@types/react-dom": "^18.2.4",
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "dependencies": {
     "@hvish/redux-thaga": "file:../hvish-redux-thaga-0.2.0.tgz",
-    "@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^2.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.5",
+    "react-redux": "^9.1.2",
     "react-scripts": "5.0.1",
     "redux-saga": "^1.2.3"
   },

--- a/integration-test/src/reducer.ts
+++ b/integration-test/src/reducer.ts
@@ -17,7 +17,7 @@ export interface Task {
 
 const taskAdapter = createEntityAdapter<Task>();
 
-export const allTasksSelector = (state: { tasks: EntityState<Task> }) =>
+export const allTasksSelector = (state: { tasks: EntityState<Task, string> }) =>
   taskAdapter.getSelectors().selectAll(state.tasks);
 
 const taskApi = async (shouldFail: boolean) => {
@@ -33,7 +33,7 @@ export const fetchTasks = createThagaAction(
   function* fetchTasksWorker({ shouldFail }: { shouldFail: boolean }) {
     const tasks = (yield call(taskApi, shouldFail)) as Task[];
     return tasks;
-  }
+  },
 );
 
 export const { actions, reducer: tasksReducer } = createSlice({
@@ -43,7 +43,7 @@ export const { actions, reducer: tasksReducer } = createSlice({
     addTask(state, action: PayloadAction<Task>) {
       taskAdapter.addOne(state, action.payload);
     },
-    updateTask(state, action: PayloadAction<Update<Task>>) {
+    updateTask(state, action: PayloadAction<Update<Task, string>>) {
       taskAdapter.updateOne(state, action.payload);
     },
   },

--- a/integration-test/src/setupTests.ts
+++ b/integration-test/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';

--- a/integration-test/src/store.ts
+++ b/integration-test/src/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, Middleware } from '@reduxjs/toolkit';
 import createSagaMiddleware from 'redux-saga';
 import { createThagaMiddleware } from '@hvish/redux-thaga';
 
@@ -10,7 +10,12 @@ const thagaMiddleware = createThagaMiddleware();
 export const store = configureStore({
   reducer: { tasks: tasksReducer },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(sagaMiddleware, thagaMiddleware),
+    // redux-saga 1.x predates RTK 2's UnknownAction typing; cast until
+    // upstream ships RTK 2-compatible types.
+    getDefaultMiddleware().concat(
+      sagaMiddleware as unknown as Middleware,
+      thagaMiddleware,
+    ),
 });
 
 sagaMiddleware.run(tasksWorker);

--- a/integration-test/tsconfig.json
+++ b/integration-test/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -14,13 +10,11 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@commitlint/config-conventional": "^21.0.2",
         "@eslint/js": "^10.0.1",
         "@jest/globals": "^30.4.1",
-        "@reduxjs/toolkit": "^1.9.5",
+        "@reduxjs/toolkit": "^2.12.0",
         "@swc/core": "^1.15.43",
         "@swc/jest": "^0.2.39",
         "eslint": "^10.5.0",
@@ -2114,19 +2114,22 @@
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
-      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -2542,6 +2545,20 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.15.43",
@@ -5255,10 +5272,11 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7277,13 +7295,11 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "license": "MIT"
     },
     "node_modules/redux-saga": {
       "version": "1.5.0",
@@ -7297,12 +7313,13 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/require-directory": {
@@ -7326,10 +7343,11 @@
       }
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
-      "dev": true
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/js": "^10.0.1",
     "@jest/globals": "^30.4.1",
-    "@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^2.12.0",
     "@swc/core": "^1.15.43",
     "@swc/jest": "^0.2.39",
     "eslint": "^10.5.0",
@@ -72,7 +72,7 @@
     "typescript-eslint": "^8.62.0"
   },
   "peerDependencies": {
-    "@reduxjs/toolkit": ">= 1",
+    "@reduxjs/toolkit": ">= 2",
     "redux-saga": ">= 1"
   }
 }

--- a/src/createThagaAction.ts
+++ b/src/createThagaAction.ts
@@ -77,7 +77,7 @@ export function createThagaAction<
   actionCreator.type = type;
   actionCreator.toString = () => type;
 
-  actionCreator.match = (action: Action<unknown>): action is PayloadAction =>
+  actionCreator.match = (action: Action): action is PayloadAction =>
     action.type === type;
 
   actionCreator.worker = function* (

--- a/src/createThagaMiddleware.test.ts
+++ b/src/createThagaMiddleware.test.ts
@@ -1,17 +1,17 @@
 import { expect, jest, test } from '@jest/globals';
 import { createThagaMiddleware } from './createThagaMiddleware';
-import { AnyAction, Dispatch, MiddlewareAPI } from '@reduxjs/toolkit';
+import { UnknownAction, MiddlewareAPI } from '@reduxjs/toolkit';
 import { createThagaAction } from './createThagaAction';
 
 test('should return a redux middleware', () => {
-  const action: AnyAction = { type: 'testAction' };
-  const nextAction: AnyAction = { type: 'nextAction' };
+  const action: UnknownAction = { type: 'testAction' };
+  const nextAction: UnknownAction = { type: 'nextAction' };
 
   const next = jest.fn().mockImplementation(() => nextAction);
   const api = {} as MiddlewareAPI;
 
   const thagaMiddleware = createThagaMiddleware();
-  const result = thagaMiddleware(api)(next as Dispatch<AnyAction>)(action);
+  const result = thagaMiddleware(api)(next)(action);
   expect(next).toHaveBeenNthCalledWith(1, action);
   expect(result).toBe(nextAction);
 });
@@ -29,7 +29,7 @@ test('should resolve when finished action is dispatched', async () => {
   const api = {} as MiddlewareAPI;
   const initiatorAction = thagaAction();
 
-  const dispatch = thagaMiddleware(api)(next as Dispatch<AnyAction>);
+  const dispatch = thagaMiddleware(api)(next);
 
   const promise = dispatch(initiatorAction);
   dispatch(thagaAction.finished(successPayload, initiatorAction));
@@ -46,7 +46,7 @@ test('should reject when failed action is dispatched', async () => {
   const api = {} as MiddlewareAPI;
   const initiatorAction = thagaAction();
 
-  const dispatch = thagaMiddleware(api)(next as Dispatch<AnyAction>);
+  const dispatch = thagaMiddleware(api)(next);
 
   try {
     const promise = dispatch(initiatorAction);
@@ -68,7 +68,7 @@ test('should reject when cancelled action is dispatched', async () => {
   const api = {} as MiddlewareAPI;
   const initiatorAction = thagaAction({ name: 'hello' });
 
-  const dispatch = thagaMiddleware(api)(next as Dispatch<AnyAction>);
+  const dispatch = thagaMiddleware(api)(next);
 
   try {
     const promise = dispatch(initiatorAction);

--- a/src/createThagaMiddleware.ts
+++ b/src/createThagaMiddleware.ts
@@ -1,4 +1,4 @@
-import { Action, Dispatch, Middleware } from '@reduxjs/toolkit';
+import { Dispatch, Middleware } from '@reduxjs/toolkit';
 import { thagaConfig } from './config';
 import { isThagaAction } from './utils';
 
@@ -19,7 +19,7 @@ export function createThagaMiddleware<DispatchExt, S, D extends Dispatch>({
     thagaConfig.setIdFn(getId);
   }
 
-  return (_api) => (next) => (action: Action) => {
+  return (_api) => (next) => (action) => {
     const result = next(action);
 
     if (!isThagaAction(action)) return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { AnyAction, PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction } from '@reduxjs/toolkit';
 import { ThagaMetaData } from './types';
 
 export function randomStr() {
@@ -6,8 +6,8 @@ export function randomStr() {
 }
 
 export function isThagaAction<Payload, Type extends string, E = any>(
-  action: AnyAction,
+  action: unknown,
 ): action is PayloadAction<Payload, Type, ThagaMetaData, E> {
-  if (action.meta?.thaga) return true;
-  return false;
+  const meta = (action as { meta?: ThagaMetaData } | null | undefined)?.meta;
+  return !!meta?.thaga;
 }


### PR DESCRIPTION
## Summary
Drops support for `@reduxjs/toolkit` v1 and aligns the type surface with RTK v2's stricter action typing.

- `peerDependencies["@reduxjs/toolkit"]`: `>= 1` → `>= 2`
- `isThagaAction` now accepts `unknown` and narrows internally (matches RTK 2's `UnknownAction` middleware contract)
- `createThagaMiddleware`: inner action param is `unknown`; narrowed by `isThagaAction`
- `createThagaAction`'s `match` drops the redundant `<unknown>` generic (RTK 2 constrains `Action<T>` to `T extends string`)
- Tests: `AnyAction` → `UnknownAction`; redundant `Dispatch` casts removed
- README notes the v2+ requirement

## Breaking change
This is a breaking change to the peer-dependency range and should ship as a minor version bump while < 1.0 (e.g. 0.3.0).

Closes #11.

## Test plan
- [x] `npm run lint` / `format:check` / `typecheck` / `build` / `test` all green locally
- [x] CI green on Node 22 + 24