### PR TITLE
ci: manual npm publish workflow (OIDC + provenance) and README badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: publish
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test
+
+      - name: Read package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if tag already exists
+        run: |
+          if git rev-parse "v${{ steps.pkg.outputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.pkg.outputs.version }} already exists. Bump package.json first."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        # OIDC + trusted publishing handles auth; --provenance attaches the
+        # cryptographic source attestation visible on npmjs.com.
+        run: npm publish --provenance --access public
+
+      - name: Tag and create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ steps.pkg.outputs.version }}"
+          git tag "$tag"
+          git push origin "$tag"
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Vishnu Singh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Redux thaga
 
-![tests](https://github.com/HVish/redux-thaga/actions/workflows/tests.yml/badge.svg)
+[![npm version](https://img.shields.io/npm/v/@hvish/redux-thaga.svg)](https://www.npmjs.com/package/@hvish/redux-thaga)
+[![npm downloads](https://img.shields.io/npm/dm/@hvish/redux-thaga.svg)](https://www.npmjs.com/package/@hvish/redux-thaga)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@hvish/redux-thaga)](https://bundlephobia.com/package/@hvish/redux-thaga)
+[![license](https://img.shields.io/npm/l/@hvish/redux-thaga.svg)](https://github.com/HVish/redux-thaga/blob/main/LICENSE)
+[![tests](https://github.com/HVish/redux-thaga/actions/workflows/tests.yml/badge.svg)](https://github.com/HVish/redux-thaga/actions/workflows/tests.yml)
 
 This redux middleware enhances redux-saga with redux-thunk capabilites.
 


### PR DESCRIPTION
## Summary
Adds a manually-triggered release workflow and packaging niceties.

- **`publish.yml`** — `workflow_dispatch`. Runs the full CI gate, then `npm publish --provenance --access public` via OIDC trusted publishing (no `NPM_TOKEN` secret). Tags the commit and creates a GitHub Release with auto-generated notes.
- **Tag-collision guard** — fails fast if `vX.Y.Z` already exists, forcing an explicit `package.json` bump before re-running.
- **README badges** — npm version, monthly downloads, gzipped bundle size, license, tests. Auto-populate after first publish.
- **`LICENSE`** — added MIT (was missing; `package.json` already declared it).

## One-time external setup before first run
On npmjs.com → `@hvish/redux-thaga` → Settings → Publishing access → add a Trusted Publisher:
- Organization/user: `HVish`
- Repository: `redux-thaga`
- Workflow filename: `publish.yml`
- Environment: (leave blank)

## Release flow after this lands
1. Bump version in `package.json` (regular commit on main).
2. Actions tab → "publish" → "Run workflow".
3. Workflow verifies, publishes with provenance, tags, and creates the GitHub Release.

## Test plan
- [x] CI green on Node 22 + 24
- [x] npmjs.com Trusted Publisher configured (manual step before first publish)