### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hvish/redux-thaga",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hvish/redux-thaga",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hvish/redux-thaga",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0",
   "description": "redux middleware for redux-saga with redux-thunk capabilities",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump from `1.0.0-rc.0` → `1.0.0`. Pre-release was successfully validated end-to-end against `@next` ([run 28014977234](https://github.com/HVish/redux-thaga/actions/runs/28014977234)).

After merge: trigger `publish` workflow on `main` to ship `1.0.0` to the `latest` dist-tag.