### PR TITLE
feat: type-augment dispatch for thaga actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ function App() {
 
   const onClick = async () => {
     try {
-      const tasks = (await dispatch(fetchTasks())) as unknown as Task[];
+      const tasks = await dispatch(fetchTasks());
       console.log(tasks);
     } catch (error) {
       console.log('unable to fetch tasks');

--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ function App() {
 export default App;
 ```
 
+## Typed dispatch
+
+Importing anything from `@hvish/redux-thaga` augments Redux's `Dispatch` (and
+redux-thunk's `ThunkDispatch`, which `configureStore` uses by default), so
+dispatching a thaga action returns a fully typed `ThagaPromise` — no casts and
+no store wiring required:
+
+```ts
+const dispatch = useDispatch();
+
+const tasks = await dispatch(fetchTasks()); // inferred as Task[]
+dispatch(fetchTasks()).cancel('user navigated away'); // ThagaPromise<Task[]>
+```
+
+Typed hooks (`useDispatch<AppDispatch>()`) work the same way. Under the hood
+the worker's return type rides along on the initiator action via the phantom
+`THAGA_RETURN` property (see `ThagaInitiatorAction`) — nothing extra exists at
+runtime. The augmentation needs `redux` and `redux-thunk` to be resolvable by
+TypeScript; both are declared as peer dependencies, so a regular install
+already satisfies this (including under pnpm and Yarn PnP).
+
 ## API
 
 ### `createThagaMiddleware(options?)`
@@ -173,6 +194,7 @@ import {
   createThagaMiddleware,
   isThagaAction,
   serializeError,
+  THAGA_RETURN,
   ThagaCancelledError,
   ThagaTimeoutError,
 } from '@hvish/redux-thaga';
@@ -180,6 +202,7 @@ import type {
   CreateThagaActionOptions,
   CreateThagaMiddlewareOptions,
   SerializedError,
+  ThagaInitiatorAction,
   ThagaMetaData,
   ThagaPromise,
 } from '@hvish/redux-thaga';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,20 +9,38 @@ export default defineConfig([
     'coverage/**',
     'integration-test/**',
     'node_modules/**',
+    'tsup.config.ts',
   ]),
   {
-    files: ['**/*.{js,ts}'],
-    extends: [js.configs.recommended, tseslint.configs.recommended],
+    files: ['**/*.ts'],
+    extends: [js.configs.recommended, tseslint.configs.recommendedTypeChecked],
     languageOptions: {
       globals: { ...globals.node },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
-      // TODO: tighten to 'error' and remove remaining `any`s in a follow-up PR
-      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+    },
+  },
+  {
+    files: ['**/*.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  {
+    // Module-augmentation type parameters must match the augmented interface
+    // verbatim; they're required by interface merging even when unreferenced.
+    files: ['**/augmentation.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,6 @@ export default defineConfig([
     'coverage/**',
     'integration-test/**',
     'node_modules/**',
-    'tsup.config.ts',
   ]),
   {
     files: ['**/*.ts'],
@@ -17,7 +16,10 @@ export default defineConfig([
     languageOptions: {
       globals: { ...globals.node },
       parserOptions: {
-        projectService: true,
+        projectService: {
+          // Typed linting for config files living outside tsconfig's `include`.
+          allowDefaultProject: ['tsup.config.ts'],
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -29,7 +31,7 @@ export default defineConfig([
     },
   },
   {
-    files: ['**/*.js'],
+    files: ['**/*.{js,mjs}'],
     extends: [js.configs.recommended],
     languageOptions: {
       globals: { ...globals.node },

--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -8,7 +8,7 @@
       "name": "redux-thunk-react-example",
       "version": "0.1.0",
       "dependencies": {
-        "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0-rc.0.tgz",
+        "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0.tgz",
         "@reduxjs/toolkit": "^2.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2261,9 +2261,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@hvish/redux-thaga": {
-      "version": "1.0.0-rc.0",
-      "resolved": "file:../hvish-redux-thaga-1.0.0-rc.0.tgz",
-      "integrity": "sha512-/DJFjCoPANylvebCyi59uSrFH5byHYbJEjiz8ThsdUQgrPeV0ILYzV+cw2/kmMXsQz86xHgKmA5/eNlxoVCCaw==",
+      "version": "1.0.0",
+      "resolved": "file:../hvish-redux-thaga-1.0.0.tgz",
+      "integrity": "sha512-D7CMWSQloRdDkYl9gbOwXjp+LYA9mPQw6iD3zoIyfiO9boHF1Yor5Ka9SDMKFbMLumxXnAfe9cMTsF0gtB1DAw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -8,7 +8,7 @@
       "name": "redux-thunk-react-example",
       "version": "0.1.0",
       "dependencies": {
-        "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0.tgz",
+        "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.1.0-rc.0.tgz",
         "@reduxjs/toolkit": "^2.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2261,16 +2261,18 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@hvish/redux-thaga": {
-      "version": "1.0.0",
-      "resolved": "file:../hvish-redux-thaga-1.0.0.tgz",
-      "integrity": "sha512-D7CMWSQloRdDkYl9gbOwXjp+LYA9mPQw6iD3zoIyfiO9boHF1Yor5Ka9SDMKFbMLumxXnAfe9cMTsF0gtB1DAw==",
+      "version": "1.1.0-rc.0",
+      "resolved": "file:../hvish-redux-thaga-1.1.0-rc.0.tgz",
+      "integrity": "sha512-YCsXi/doGgly5kNH1AogbBFBXUv3Yu5pT91lpkWOXZb0c+cUSn/olFzb99LPFYto4rMAzTLRw3a8tL4VE0Zh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
         "@reduxjs/toolkit": ">= 2",
-        "redux-saga": ">= 1"
+        "redux": ">= 5",
+        "redux-saga": ">= 1",
+        "redux-thunk": ">= 3"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0.tgz",
+    "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.1.0-rc.0.tgz",
     "@reduxjs/toolkit": "^2.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0-rc.0.tgz",
+    "@hvish/redux-thaga": "file:../hvish-redux-thaga-1.0.0.tgz",
     "@reduxjs/toolkit": "^2.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/integration-test/src/App.tsx
+++ b/integration-test/src/App.tsx
@@ -7,6 +7,7 @@ import {
   SerializedError,
 } from '@hvish/redux-thaga';
 import { Task, allTasksSelector, fetchTasks, slowFetchTasks } from './reducer';
+import type { AppDispatch } from './store';
 
 type Outcome =
   | { kind: 'idle' }
@@ -35,7 +36,7 @@ function describe(o: Outcome): string {
 
 function App() {
   const tasks = useSelector(allTasksSelector);
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const [outcome, setOutcome] = useState<Outcome>({ kind: 'idle' });
   const [inFlight, setInFlight] = useState<ThagaPromise<unknown> | null>(null);
 
@@ -66,26 +67,13 @@ function App() {
   };
 
   const onSuccess = () =>
-    handle(
-      'Success',
-      dispatch(
-        fetchTasks({ shouldFail: false }),
-      ) as unknown as ThagaPromise<unknown>,
-    );
+    handle('Success', dispatch(fetchTasks({ shouldFail: false })));
 
   const onFailure = () =>
-    handle(
-      'Failure',
-      dispatch(
-        fetchTasks({ shouldFail: true }),
-      ) as unknown as ThagaPromise<unknown>,
-    );
+    handle('Failure', dispatch(fetchTasks({ shouldFail: true })));
 
   const onSlow = () =>
-    handle(
-      'Slow (per-action timeoutMs=1500)',
-      dispatch(slowFetchTasks()) as unknown as ThagaPromise<unknown>,
-    );
+    handle('Slow (per-action timeoutMs=1500)', dispatch(slowFetchTasks()));
 
   const onCancel = () => {
     if (inFlight) inFlight.cancel('user clicked cancel');

--- a/integration-test/src/store.ts
+++ b/integration-test/src/store.ts
@@ -19,3 +19,5 @@ export const store = configureStore({
 });
 
 sagaMiddleware.run(tasksWorker);
+
+export type AppDispatch = typeof store.dispatch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hvish/redux-thaga",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hvish/redux-thaga",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
@@ -23,7 +23,9 @@
         "jest": "^30.4.2",
         "lint-staged": "^17.0.8",
         "prettier": "^3.8.4",
+        "redux": "^5.0.1",
         "redux-saga": "^1.5.0",
+        "redux-thunk": "^3.1.0",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0"
@@ -33,7 +35,9 @@
       },
       "peerDependencies": {
         "@reduxjs/toolkit": ">= 2",
-        "redux-saga": ">= 1"
+        "redux": ">= 5",
+        "redux-saga": ">= 1",
+        "redux-thunk": ">= 3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "url": "https://github.com/HVish/redux-thaga/issues"
   },
   "main": "dist/cjs/redux-thaga.cjs",
-  "module": "dist/redux-thaga.legacy-esm.js",
   "types": "dist/cjs/redux-thaga.d.ts",
   "exports": {
     "./package.json": "./package.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hvish/redux-thaga",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "description": "redux middleware for redux-saga with redux-thunk capabilities",
   "repository": {
     "type": "git",
@@ -66,13 +66,17 @@
     "jest": "^30.4.2",
     "lint-staged": "^17.0.8",
     "prettier": "^3.8.4",
+    "redux": "^5.0.1",
     "redux-saga": "^1.5.0",
+    "redux-thunk": "^3.1.0",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0"
   },
   "peerDependencies": {
     "@reduxjs/toolkit": ">= 2",
-    "redux-saga": ">= 1"
+    "redux": ">= 5",
+    "redux-saga": ">= 1",
+    "redux-thunk": ">= 3"
   }
 }

--- a/src/augmentation.ts
+++ b/src/augmentation.ts
@@ -1,0 +1,35 @@
+import type { Action, UnknownAction } from '@reduxjs/toolkit';
+import type { ThagaInitiatorAction, ThagaPromise } from './types';
+
+/**
+ * Augment Redux's `Dispatch` with a thaga overload. When a thaga initiator
+ * action is dispatched, the returned value is a `ThagaPromise` whose value
+ * type is the worker's `ReturnPayload`. This mirrors the pattern redux-thunk
+ * uses to type-augment `dispatch`.
+ *
+ * The overload is matched whenever the dispatched action satisfies
+ * `ThagaInitiatorAction`. Plain actions continue to resolve to Redux's
+ * default `(action: T) => T` overload.
+ */
+declare module 'redux' {
+  interface Dispatch<A extends Action = UnknownAction> {
+    <Payload, ReturnPayload, Type extends string>(
+      action: ThagaInitiatorAction<Payload, ReturnPayload, Type>,
+    ): ThagaPromise<ReturnPayload>;
+  }
+}
+
+/**
+ * `configureStore` includes redux-thunk by default, whose `ThunkDispatch`
+ * exposes a catch-all `<A extends BasicAction>(action: A) => A` overload that
+ * would otherwise outcompete the thaga overload on `Dispatch`. Augment
+ * `ThunkDispatch` so the thaga overload is tried first when a thaga initiator
+ * action is dispatched.
+ */
+declare module 'redux-thunk' {
+  interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action> {
+    <Payload, ReturnPayload, Type extends string>(
+      action: ThagaInitiatorAction<Payload, ReturnPayload, Type>,
+    ): ThagaPromise<ReturnPayload>;
+  }
+}

--- a/src/createThagaAction.test.ts
+++ b/src/createThagaAction.test.ts
@@ -28,12 +28,7 @@ function expectThagaActionCreator(
 ) {
   expect(typeof actionCreator).toBe('function');
 
-  const action = (
-    actionCreator as unknown as (...args: unknown[]) => {
-      type: string;
-      meta?: unknown;
-    }
-  )(...args);
+  const action = actionCreator(...(args as never[]));
 
   expect(actionCreator).toHaveProperty('match');
   expect(actionCreator.match(action)).toBe(true);

--- a/src/createThagaAction.test.ts
+++ b/src/createThagaAction.test.ts
@@ -16,10 +16,24 @@ function* actionWorker(
 
 const thagaActionCreator = createThagaAction(thagaName, actionWorker);
 
-function expectThagaActionCreator(actionCreator: any, ...args: any[]) {
+type ThagaActionCreatorLike = {
+  type: string;
+  toString: () => string;
+  match: (action: Action) => boolean;
+} & ((...args: never[]) => { type: string; meta?: unknown });
+
+function expectThagaActionCreator(
+  actionCreator: ThagaActionCreatorLike,
+  ...args: unknown[]
+) {
   expect(typeof actionCreator).toBe('function');
 
-  const action = actionCreator(...args);
+  const action = (
+    actionCreator as unknown as (...args: unknown[]) => {
+      type: string;
+      meta?: unknown;
+    }
+  )(...args);
 
   expect(actionCreator).toHaveProperty('match');
   expect(actionCreator.match(action)).toBe(true);

--- a/src/createThagaAction.ts
+++ b/src/createThagaAction.ts
@@ -6,7 +6,7 @@ import {
   put,
 } from 'redux-saga/effects';
 
-import { SerializedError, ThagaMetaData } from './types';
+import type { ThagaInitiatorAction, ThagaMetaData } from './types';
 import { thagaConfig } from './config';
 import { serializeError } from './utils';
 
@@ -23,14 +23,14 @@ export function createThagaAction<
   Payload = void,
   ReturnPayload = void,
   Type extends string = string,
-  ExtraArgs extends Array<any> = any,
+  ExtraArgs extends readonly unknown[] = [],
 >(
   type: Type,
   worker: (
     paylod: Payload,
     action: PayloadAction<Payload, Type, ThagaMetaData>,
     ...args: ExtraArgs
-  ) => Generator<any, ReturnPayload, unknown>,
+  ) => Generator<unknown, ReturnPayload, unknown>,
   options: CreateThagaActionOptions = {},
 ) {
   const cancelled = createAction(
@@ -44,7 +44,7 @@ export function createThagaAction<
         thaga: true,
         id: initiatorAction.meta.id,
         cancelled: true,
-      } as ThagaMetaData,
+      },
     }),
   );
 
@@ -54,12 +54,12 @@ export function createThagaAction<
       initiatorAction: PayloadAction<Payload, Type, ThagaMetaData>,
       error: unknown,
     ) => ({
-      payload: serializeError(error) as SerializedError,
+      payload: serializeError(error),
       meta: {
         thaga: true,
         id: initiatorAction.meta.id,
         failed: true,
-      } as ThagaMetaData,
+      },
     }),
   );
 
@@ -74,11 +74,13 @@ export function createThagaAction<
         thaga: true,
         id: initiatorAction.meta.id,
         finished: true,
-      } as ThagaMetaData,
+      },
     }),
   );
 
-  function actionCreator(payload: Payload) {
+  function actionCreator(
+    payload: Payload,
+  ): ThagaInitiatorAction<Payload, ReturnPayload, Type> {
     const meta: ThagaMetaData = { thaga: true, id: thagaConfig.getId() };
     if (options.timeoutMs !== undefined) meta.timeoutMs = options.timeoutMs;
     const action: PayloadAction<Payload, Type, ThagaMetaData> = {
@@ -104,12 +106,12 @@ export function createThagaAction<
     ...args: ExtraArgs
   ) {
     try {
-      const result: ReturnPayload = yield call(
+      const result = (yield call(
         worker,
         initiatorAction.payload,
         initiatorAction,
         ...args,
-      );
+      )) as ReturnPayload;
       yield put(finished(result, initiatorAction));
     } catch (error) {
       yield put(failed(initiatorAction, error));

--- a/src/createThagaMiddleware.ts
+++ b/src/createThagaMiddleware.ts
@@ -1,13 +1,8 @@
 import { Dispatch, Middleware } from '@reduxjs/toolkit';
 import { thagaConfig } from './config';
 import { isThagaAction } from './utils';
-import {
-  SerializedError,
-  ThagaCancelledError,
-  ThagaMetaData,
-  ThagaPromise,
-  ThagaTimeoutError,
-} from './types';
+import { ThagaCancelledError, ThagaTimeoutError } from './types';
+import type { ThagaMetaData, ThagaPromise } from './types';
 
 export interface CreateThagaMiddlewareOptions {
   /** Unique id generator function; used to correlate initiator and terminal actions. */
@@ -63,7 +58,7 @@ export function createThagaMiddleware<DispatchExt, S, D extends Dispatch>({
         entry.reject(new ThagaCancelledError(action.payload));
       } else {
         // failed: payload is a SerializedError
-        entry.reject(action.payload as SerializedError);
+        entry.reject(action.payload);
       }
 
       return result;
@@ -87,7 +82,7 @@ export function createThagaMiddleware<DispatchExt, S, D extends Dispatch>({
 
     promise.cancel = (reason?: unknown) => {
       if (!pending.has(id)) return;
-      api.dispatch({
+      void api.dispatch({
         type: `${initiatorType}/cancelled`,
         payload: reason,
         meta: {

--- a/src/dispatch-types.test.ts
+++ b/src/dispatch-types.test.ts
@@ -1,0 +1,87 @@
+import './augmentation';
+import {
+  configureStore,
+  type Dispatch,
+  type UnknownAction,
+} from '@reduxjs/toolkit';
+import type { ThunkDispatch } from 'redux-thunk';
+import { test } from '@jest/globals';
+
+import { createThagaAction } from './createThagaAction';
+import { createThagaMiddleware } from './createThagaMiddleware';
+import type { ThagaInitiatorAction, ThagaPromise } from './types';
+
+// Compile-time type assertion helpers. These are not runtime checks — if the
+// type relationship breaks, `tsc --noEmit` (run via `npm run typecheck` and in
+// CI) fails. The `_*` prefix keeps the unused-vars rule satisfied for what
+// are otherwise type-only assertions.
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+const _thagaActionCreator = createThagaAction<{ id: string }, number, 'fetch'>(
+  'fetch',
+  function* (_payload, _action) {
+    yield;
+    return 42;
+  },
+);
+
+// 1. The action creator returns a branded `ThagaInitiatorAction`, threading
+//    `ReturnPayload` through the phantom carrier.
+type _ActionShape = ReturnType<typeof _thagaActionCreator>;
+type _expectAction = Expect<
+  Equals<_ActionShape, ThagaInitiatorAction<{ id: string }, number, 'fetch'>>
+>;
+
+// 2. A plain `Dispatch` (after augmentation) resolves a thaga action to
+//    `ThagaPromise<ReturnPayload>`.
+declare const _plainDispatch: Dispatch<UnknownAction>;
+type _expectPlainDispatchThaga = Expect<
+  Equals<
+    ReturnType<typeof _plainDispatch<{ id: string }, number, 'fetch'>>,
+    ThagaPromise<number>
+  >
+>;
+
+// 3. RTK's default middleware stack (thunk + thaga) yields a dispatch that
+//    still resolves thaga actions to `ThagaPromise<ReturnPayload>`. This is
+//    the case the augmentation of `ThunkDispatch` exists to cover.
+const _store = configureStore({
+  reducer: () => ({}),
+  middleware: (getDefault) => getDefault().concat(createThagaMiddleware()),
+});
+declare const _storeDispatch: typeof _store.dispatch;
+type _expectStoreDispatchThaga = Expect<
+  Equals<
+    ReturnType<typeof _storeDispatch<{ id: string }, number, 'fetch'>>,
+    ThagaPromise<number>
+  >
+>;
+
+// 4. Plain (non-thaga) actions on the store still type-check and return the
+//    action itself (Dispatch's default overload).
+declare const _plainAction: { type: 'plain'; payload: string };
+type _expectPlainDispatched = Expect<
+  Equals<
+    ReturnType<typeof _storeDispatch<typeof _plainAction>>,
+    typeof _plainAction
+  >
+>;
+
+// 5. `ThunkDispatch` directly (without intersection) also picks the thaga
+//    overload — needed because `useDispatch<AppDispatch>()` can resolve to it.
+declare const _thunkDispatch: ThunkDispatch<unknown, undefined, UnknownAction>;
+type _expectThunkDispatchThaga = Expect<
+  Equals<
+    ReturnType<typeof _thunkDispatch<{ id: string }, number, 'fetch'>>,
+    ThagaPromise<number>
+  >
+>;
+
+test('dispatch type augmentation is wired up (compile-time only)', () => {
+  // The real assertions live in the `Expect<>` types above; this test exists
+  // so Jest counts the file alongside the rest of the suite.
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
+import './augmentation';
+
 export { createThagaAction } from './createThagaAction';
 export type { CreateThagaActionOptions } from './createThagaAction';
 export { createThagaMiddleware } from './createThagaMiddleware';
 export type { CreateThagaMiddlewareOptions } from './createThagaMiddleware';
+export { THAGA_RETURN, ThagaCancelledError, ThagaTimeoutError } from './types';
+export type {
+  SerializedError,
+  ThagaInitiatorAction,
+  ThagaMetaData,
+  ThagaPromise,
+} from './types';
 export { isThagaAction, serializeError } from './utils';
-export { ThagaCancelledError, ThagaTimeoutError } from './types';
-export type { SerializedError, ThagaMetaData, ThagaPromise } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+
 export interface ThagaMetaData {
   thaga: true;
   id: string;
@@ -18,13 +20,23 @@ export interface SerializedError {
   code?: string;
 }
 
+function stringifyReason(reason: unknown): string {
+  if (typeof reason === 'string') return reason;
+  if (reason instanceof Error) return reason.message;
+  try {
+    return JSON.stringify(reason) ?? String(reason);
+  } catch {
+    return Object.prototype.toString.call(reason);
+  }
+}
+
 export class ThagaCancelledError extends Error {
   override name = 'ThagaCancelledError';
   constructor(public readonly reason?: unknown) {
     super(
       reason === undefined
         ? 'Thaga action was cancelled'
-        : `Thaga action was cancelled: ${String(reason)}`,
+        : `Thaga action was cancelled: ${stringifyReason(reason)}`,
     );
   }
 }
@@ -35,6 +47,29 @@ export class ThagaTimeoutError extends Error {
     super(`Thaga action timed out after ${timeoutMs}ms`);
   }
 }
+
+/**
+ * Phantom property carrier used to thread a thaga worker's return type
+ * through to `dispatch()`. The property is never set at runtime — it exists
+ * only so the compiler can recover `ReturnPayload` from the initiator action.
+ */
+export const THAGA_RETURN: unique symbol = Symbol.for(
+  '@hvish/redux-thaga/return',
+);
+export type THAGA_RETURN = typeof THAGA_RETURN;
+
+/**
+ * A thaga initiator action. Identical at runtime to a `PayloadAction` with
+ * `ThagaMetaData`, but carries a phantom `ReturnPayload` type that
+ * `ThagaDispatch` reads to infer the dispatched Promise's value type.
+ */
+export type ThagaInitiatorAction<
+  Payload,
+  ReturnPayload,
+  Type extends string = string,
+> = PayloadAction<Payload, Type, ThagaMetaData> & {
+  readonly [THAGA_RETURN]?: ReturnPayload;
+};
 
 export interface ThagaPromise<T> extends Promise<T> {
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ export function randomStr() {
   return (Math.random() + 1).toString(36).substring(7);
 }
 
-export function isThagaAction<Payload, Type extends string, E = any>(
+export function isThagaAction<Payload, Type extends string, E = never>(
   action: unknown,
 ): action is PayloadAction<Payload, Type, ThagaMetaData, E> {
   const meta = (action as { meta?: ThagaMetaData } | null | undefined)?.meta;
@@ -31,7 +31,7 @@ export function serializeError(error: unknown): SerializedError {
     const obj = error as Record<string, unknown>;
     const out: SerializedError = {};
     for (const key of ['name', 'message', 'stack', 'code'] as const) {
-      if (typeof obj[key] === 'string') out[key] = obj[key] as string;
+      if (typeof obj[key] === 'string') out[key] = obj[key];
     }
     if (out.message || out.name) return out;
   }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, Options } from 'tsup';
-import fs from 'fs';
 
 export default defineConfig((options) => {
   const commonOptions: Partial<Options> = {
@@ -16,12 +15,6 @@ export default defineConfig((options) => {
       outExtension: () => ({ js: '.mjs' }),
       dts: true,
       clean: true,
-      async onSuccess() {
-        fs.copyFileSync(
-          'dist/redux-thaga.mjs',
-          'dist/redux-thaga.legacy-esm.js'
-        );
-      },
     },
     {
       ...commonOptions,


### PR DESCRIPTION
Closes #3

## Summary

- Augment redux's `Dispatch` (and redux-thunk's `ThunkDispatch`) so `dispatch(thagaAction(payload))` returns a typed `ThagaPromise<ReturnPayload>` — no more casts at call sites. The worker's return type rides on the initiator action via a phantom `THAGA_RETURN` property (nothing extra at runtime); exported as `ThagaInitiatorAction`.
- Declare `redux` and `redux-thunk` as peer dependencies so the augmentation resolves under strict node_modules layouts (pnpm, Yarn PnP).
- Document typed dispatch in the README and update the example app to drop its casts.
- Tighten ESLint to `recommendedTypeChecked` with typed linting, remove the remaining `any`s, and lint `tsup.config.ts` again.
- Drop the legacy `module` field from package.json (the `exports` map covers modern bundlers); bump to `1.1.0-rc.0`.

## Test plan

- Compile-time assertions in `src/dispatch-types.test.ts` cover plain `Dispatch`, RTK's store dispatch, bare `ThunkDispatch`, and non-thaga actions; enforced by `npm run typecheck` in CI.
- Verified the bundled `.d.ts` (ESM + CJS) retains both `declare module` blocks.
- `integration-test` app typechecks against the packed tarball with no casts.
- `lint`, `format:check`, `typecheck`, `build`, and all 25 unit tests pass.